### PR TITLE
Support parentheses methods in migration

### DIFF
--- a/check_indexes.sh
+++ b/check_indexes.sh
@@ -107,7 +107,7 @@ parse_migration() {
   local in_create_table=false
 
   while IFS= read -r line; do
-    line=$(echo "$line" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+    line=$(echo "$line" | sed -e 's/[()]/ /g' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
 
     if echo "$line" | grep -q "create_table"; then
       current_table=$(echo "$line" | extract_table_name)

--- a/test/migration-index-test.bats
+++ b/test/migration-index-test.bats
@@ -202,6 +202,29 @@ end'
   [[ "$output" =~ "Missing index for foreign key column 'post_id' in table 'comments'" ]]
 }
 
+@test "handles parentheses methods in migration" {
+  create_schema '
+  create_table "comments", force: :cascade do |t|
+    t.integer "post_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end'
+
+  create_migration "20240101000000_create_comments.rb" '
+class CreateComments < ActiveRecord::Migration[7.2]
+  def change
+    create_table(:comments) do |t|
+      t.integer(:post_id)
+      t.timestamps
+    end
+  end
+end'
+
+  run ./check_indexes.sh
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "Missing index for foreign key column 'post_id' in table 'comments'" ]]
+}
+
 @test "debug output works when enabled" {
   create_schema '
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
👋 
In the project I'm working on we use parentheses at all times.
This would not be caught.
```
class PostsAddUserId < ActiveRecord::Migration[7.1]

  def change  
    add_column(:posts, :user_id, :bigint)
  end
end
```

My suggestion is to support it, let me know if it's a bad idea. Or feel free to solve it someway else.

Best regards