### PR TITLE
Skip string _id columns from index checks and add related test

### DIFF
--- a/test/migration-index-test.bats
+++ b/test/migration-index-test.bats
@@ -570,3 +570,23 @@ end'
   [[ "$output" =~ "Missing index for foreign key column 'invited_by_user_id' in table 'invitations'" ]]
   [[ "$output" =~ "add_index :invitations, :invited_by_user_id" ]]
 }
+
+@test "passes when a new _id field of string type is added" {
+  create_schema '
+  create_table "users", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end'
+
+  create_migration "20240101000000_add_contact_id_to_users.rb" '
+class AddNameToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :contact_id, :string
+  end
+end'
+
+  run ./check_indexes.sh
+  echo "Test output:"
+  echo "$output"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- Modify index checking script to skip string type columns ending with `_id`
- Prevent false positives for string foreign key columns in migrations
- Add a test case to verify that string `_id` columns do not require indexes

## Changes

### Script Updates
- Updated `check_indexes.sh` to:
  - Only consider non-string foreign key columns for index checks
  - Skip string columns ending with `_id` during index validation
  - Add safety check for existence of keys in `COLUMN_TYPES` before accessing

### Tests
- Added a new BATS test in `migration-index-test.bats`:
  - Confirms that adding a new `_id` column of type string does not trigger missing index errors

## Test plan
- Run existing and new BATS tests to ensure no regressions
- Verify that string `_id` columns are correctly excluded from index requirement errors
- Confirm that polymorphic and other foreign key columns still require indexes as expected

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4810bfbf-2136-4361-b7a1-1f7637bde203